### PR TITLE
Output errors for nodes

### DIFF
--- a/lib/cloudcli/commands/power.rb
+++ b/lib/cloudcli/commands/power.rb
@@ -46,7 +46,8 @@ module CloudCLI
               .body
               .to_h
 
-        result['nodes'].each do |node, status|
+        nodes = result['nodes'].merge(result['errors'])
+        nodes.each do |node, status|
           puts "#{node}: #{status}"
         end
       end


### PR DESCRIPTION
Related to [this](https://github.com/openflighthpc/flight-cloud/pull/270), Flight Cloud Client will now output the adjusted error message for nodes that do not exist when a power command is ran against them.