### PR TITLE
Initial list command

### DIFF
--- a/lib/cloudcli/api.rb
+++ b/lib/cloudcli/api.rb
@@ -44,6 +44,10 @@ module CloudCLI
       connection.get("/power/#{node}/off", group: group)
     end
 
+    def list
+      connection.get("/list")
+    end
+
     private
 
     def url

--- a/lib/cloudcli/cli.rb
+++ b/lib/cloudcli/cli.rb
@@ -29,6 +29,7 @@
 require 'commander'
 require 'cloudcli/config'
 require 'cloudcli/commands/power'
+require 'cloudcli/commands/list'
 
 module CloudCLI
   # TODO: Move me to a new file
@@ -97,6 +98,13 @@ module CloudCLI
         Run the command over a group of nodes given by NODE_IDENTIFIER
       OPT
       action(c, Commands::Power)
+    end
+
+    command('list') do |c|
+      cli_syntax(c)
+      c.summary = 'Return a list of nodes and the domain'
+      c.option '-g', '--group', 'Filter the list by group'
+      action(c, Commands::List)
     end
   end
 end

--- a/lib/cloudcli/cli.rb
+++ b/lib/cloudcli/cli.rb
@@ -103,6 +103,7 @@ module CloudCLI
     command('list') do |c|
       cli_syntax(c)
       c.summary = 'Return a list of nodes and the domain'
+      c.option '-a', '--all', 'List all nodes and domains'
       c.option '-g', '--group', 'Filter the list by group'
       action(c, Commands::List)
     end

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd
+#
+# This file is part of flight-cloud-cli
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on flight-account, please visit:
+# https://github.com/openflighthpc/flight-cloud-cli
+#===============================================================================
+
+module CloudCLI
+  module Commands
+    class List
+      def initialize
+        require 'cloudcli/api'
+      end
+
+      def run!
+
+      end
+
+      def run
+
+      end
+    end
+  end
+end

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -29,16 +29,38 @@
 module CloudCLI
   module Commands
     class List
+      attr_reader :all, :group
+
       def initialize
         require 'cloudcli/api'
       end
 
-      def run!
-
+      def run!(all: false, group: false)
+        @all = all
+        @group = group
+        run
       end
 
       def run
+        result = API.new(Config.ip, Config.port)
+              .public_send('list')
+              .body
 
+        deployments = result[:running]
+        deployments = deployments.merge(result[:offline]) if all
+
+        unless deployments.empty?
+          deployments.each do |deployment|
+            puts "\nDeployment: '#{deployment.first}'"
+            puts "--------------------------------------------------------"
+            puts "Status: #{deployment.last[:status]}"
+            unless deployment.last[:groups]&.nil? || deployment.last[:groups]&.empty?
+              puts "Groups: #{deployment.last[:groups]}"
+            end
+          end
+        else
+          puts "No running deployments. Use --all to view all deployments"
+        end
       end
     end
   end

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -51,11 +51,15 @@ module CloudCLI
 
         unless deployments.empty?
           deployments.each do |deployment|
-            puts "\nDeployment: '#{deployment.first}'"
+            name = deployment.first
+            groups = deployment.last[:groups]
+            status = deployment.last[:status]
+
+            puts "\nDeployment: '#{name}'"
             puts "--------------------------------------------------------"
-            puts "Status: #{deployment.last[:status]}"
-            unless deployment.last[:groups]&.nil? || deployment.last[:groups]&.empty?
-              puts "Groups: #{deployment.last[:groups]}"
+            puts "Status: #{status}"
+            unless groups&.nil? || groups&.empty?
+              puts "Groups: #{groups}"
             end
           end
         else


### PR DESCRIPTION
Part of #3. This PR introduces the basic `list` command that will return a simplified version of the same command within `Flight Cloud`. Initially this only supports listing currently deployed resources with the option to list all known resources using the `--all` flag. In the future this command will be expanded upon to further meet the requirements of #3.