### PR TITLE
Support filtering the list by group

### DIFF
--- a/lib/cloudcli/api.rb
+++ b/lib/cloudcli/api.rb
@@ -44,8 +44,8 @@ module CloudCLI
       connection.get("/power/#{node}/off", group: group)
     end
 
-    def list
-      connection.get("/list")
+    def list(group)
+      connection.get("/list", group: group)
     end
 
     private

--- a/lib/cloudcli/cli.rb
+++ b/lib/cloudcli/cli.rb
@@ -104,7 +104,7 @@ module CloudCLI
       cli_syntax(c)
       c.summary = 'Return a list of nodes and the domain'
       c.option '-a', '--all', 'List all nodes and domains'
-      c.option '-g', '--group', 'Filter the list by group'
+      c.option '-g GROUP', '--group GROUP', 'Filter the list by group'
       action(c, Commands::List)
     end
   end

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -35,7 +35,7 @@ module CloudCLI
         require 'cloudcli/api'
       end
 
-      def run!(all: false, group: false)
+      def run!(all: false, group: nil)
         @all = all
         @group = group
         run

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -43,7 +43,7 @@ module CloudCLI
 
       def run
         result = API.new(Config.ip, Config.port)
-              .public_send('list')
+              .public_send('list', group)
               .body
 
         deployments = result[:running]

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -50,16 +50,12 @@ module CloudCLI
         deployments = deployments.merge(result[:offline]) if all
 
         unless deployments.empty?
-          deployments.each do |deployment|
-            name = deployment.first
-            groups = deployment.last[:groups]
-            status = deployment.last[:status]
-
-            puts "\nDeployment: '#{name}'"
+          deployments.each do |deployment, attributes|
+            puts "\nDeployment: '#{deployment}'"
             puts "--------------------------------------------------------"
-            puts "Status: #{status}"
-            unless groups&.nil? || groups&.empty?
-              puts "Groups: #{groups}"
+            puts "Status: #{attributes[:status]}"
+            unless attributes[:groups].to_s.empty?
+              puts "Groups: #{attributes[:groups]}"
             end
           end
         else

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -56,9 +56,7 @@ module CloudCLI
             puts "\nDeployment: '#{deployment}'"
             puts "--------------------------------------------------------"
             puts "Status: #{attributes[:status]}"
-            unless groups.to_s.empty?
-              puts "Groups: #{groups}"
-            end
+            puts "Groups: #{groups}" unless groups.to_s.empty?
           end
         else
           puts "No running deployments. Use --all to view all deployments"

--- a/lib/cloudcli/commands/list.rb
+++ b/lib/cloudcli/commands/list.rb
@@ -51,11 +51,13 @@ module CloudCLI
 
         unless deployments.empty?
           deployments.each do |deployment, attributes|
+            groups = attributes[:groups]
+
             puts "\nDeployment: '#{deployment}'"
             puts "--------------------------------------------------------"
             puts "Status: #{attributes[:status]}"
-            unless attributes[:groups].to_s.empty?
-              puts "Groups: #{attributes[:groups]}"
+            unless groups.to_s.empty?
+              puts "Groups: #{groups}"
             end
           end
         else


### PR DESCRIPTION
Related to [this](https://github.com/openflighthpc/flight-cloud/pull/274) PR within `Flight Cloud` this is another part of #3. This will add the `--group` flag to the `list` command dependent on the Cloud PR referenced being merged through and utilised. Once the two PRs have been merged through the user will be able to filter the list by the group specified.